### PR TITLE
Support GHC 9.0 and Template Haskell 2.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,10 @@ workflows:
       - run_build_and_test:
           name: test_latest
           latest: true
+## GHC 9 is not supported on stackage yet it seems
+#      - run_build_and_test:
+#          name: test_ghc_9.0
+#          stack_yaml: stack-ghc-9.0.yaml
       - run_build_and_test:
           name: test_ghc_8.10
           stack_yaml: stack-ghc-8.10.yaml

--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,7 @@ when:
 
 dependencies:
 - base >= 4.9 && < 5
-- template-haskell >= 2.11.1.0 && <2.17
+- template-haskell >= 2.11.1.0 && <2.18
 - th-orphans >= 0.13.4 && <0.13.12
 - transformers >= 0.5.2 && < 0.5.7
 

--- a/stack-ghc-8.10.yaml
+++ b/stack-ghc-8.10.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-08-03
+resolver: lts-17.15
 
 ghc-options:
   '$locals': -Werror

--- a/th-test-utils.cabal
+++ b/th-test-utils.cabal
@@ -39,7 +39,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.9 && <5
-    , template-haskell >=2.11.1.0 && <2.17
+    , template-haskell >=2.11.1.0 && <2.18
     , th-orphans >=0.13.4 && <0.13.12
     , transformers >=0.5.2 && <0.5.7
   if impl(ghc >= 8.0)
@@ -64,7 +64,7 @@ test-suite th-test-utils-test
     , tasty
     , tasty-golden
     , tasty-hunit
-    , template-haskell >=2.11.1.0 && <2.17
+    , template-haskell >=2.11.1.0 && <2.18
     , th-orphans >=0.13.4 && <0.13.12
     , th-test-utils
     , transformers >=0.5.2 && <0.5.7


### PR DESCRIPTION
Looks like GHC 9 works out of the box, so just a version bump. New CI for GHC 9 can't be added because it looks like stack's nightly or lts don't support it yet. Tests have been ran locally however, and do pass.